### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.10',
     install_requires=[
         'bcrypt>=3.0.0',
         'cryptography'


### PR DESCRIPTION
Only python3.10 is compatiple with current use of @staticmethod as discussed in https://github.com/scottcwang/openssh_key_parser/issues/1. Too avoid auto update issues, with python <3.10